### PR TITLE
Prefer to report the Debian package version when available.

### DIFF
--- a/package/fa_adept_client.tcl
+++ b/package/fa_adept_client.tcl
@@ -628,9 +628,9 @@ namespace eval ::fa_adept {
 		# construct some key-value pairs to be included.
 		#
 		# note that there are two possible sources for piaware_version_full.
-		# the first one found will be used.
+		# the last one found will be used.
 		#
-		foreach var "user password piaware_version image_type piaware_version_full piaware_version_full" globalVar "::flightaware_user ::flightaware_password ::piawareVersion ::imageType ::fullVersionID ::piawareVersionFull" {
+		foreach var "user password piaware_version image_type piaware_version_full piaware_version_full" globalVar "::flightaware_user ::flightaware_password ::piawareVersion ::imageType ::piawareVersionFull ::fullVersionID" {
 			if {[info exists $globalVar]} {
 				set message($var) [set $globalVar]
 			}


### PR DESCRIPTION
The intent of the version-reporting code appears to be to report the package
version if available, falling back to the hardcoded version otherwise.

However, the code doesn't match the comment - it actually picks the *last*
available value for a key, stomping on earlier values.

Update the comment and the value ordering so that the package version is
set last and takes priority over the hardcoded version.