### PR TITLE
Add support for install-to-custom-prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,18 @@
 # locate the config directory of the init system
 SYSTEMD := $(shell ls -d /etc/systemd/system/ 2>/dev/null)
 SYSVINIT := $(shell ls -d /etc/init.d/ 2>/dev/null)
+TCLSH=$(shell which tclsh || which tclsh8.5 || which tclsh8.6)
+USR_DIR := /usr
+
+ifeq ($(PREFIX),)
+    PREFIX_DIR := $(USR_DIR)
+else
+    PREFIX_DIR := $(PREFIX)/$(USR_DIR)
+    $(warning Installing to $(PREFIX))
+endif
+
+export TCLSH
+export PREFIX_DIR
 
 all:
 	@echo "'make install' as root to install client package and program"
@@ -21,7 +33,7 @@ ifdef SYSVINIT
 	install scripts/piaware-rc-script $(SYSVINIT)piaware
 else
 ifdef SYSTEMD
-	install scripts/piaware.service $(SYSTEMD)
+	install scripts/piaware.service $(PREFIX)/$(SYSTEMD)
 else
 	@echo "No init service found"
 endif

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 # makefile for piaware doc files
 #
 
-DOCDIR=/usr/share/man/man1
+DOCDIR=$(PREFIX_DIR)/share/man/man1
 
 MANPAGES= faup1090.1 piaware.1 piaware-config.1 piaware-status.1
 
@@ -11,6 +11,7 @@ all:
 
 install:
 	@echo ---- installing docs
+	install -d $(DOCDIR)
 	cp $(MANPAGES) $(DOCDIR)
 	@echo --- compressing docs
 	cd $(DOCDIR); gzip --force -9 $(MANPAGES)

--- a/package/Makefile
+++ b/package/Makefile
@@ -1,7 +1,7 @@
 
-LIB=/usr/lib/fa_adept_packages
 
-TCLSH=$(shell which tclsh || which tclsh8.5 || which tclsh8.6)
+
+LIB=$(PREFIX_DIR)/lib/fa_adept_packages
 
 FILES=fa_adept_config.tcl fa_adept_client.tcl piaware.tcl ca/DigiCertCA.crt
 

--- a/programs/piaware-config/Makefile
+++ b/programs/piaware-config/Makefile
@@ -3,9 +3,8 @@
 #  configure and do other stuff as a FlightAware adept client
 #
 
-LIB=/usr/lib
-BIN=/usr/bin
-TCLSH=tclsh8.5
+LIB=$(PREFIX_DIR)/lib
+BIN=$(PREFIX_DIR)/bin
 
 CLIENT_INSTALLFILES= *.tcl
 

--- a/programs/piaware-status/Makefile
+++ b/programs/piaware-status/Makefile
@@ -3,9 +3,8 @@
 #  get the status of the piaware toolchain
 #
 
-LIB=/usr/lib
-BIN=/usr/bin
-TCLSH=tclsh8.5
+LIB=$(PREFIX_DIR)/lib
+BIN=$(PREFIX_DIR)/bin
 
 CLIENT_INSTALLFILES= *.tcl
 

--- a/programs/piaware/Makefile
+++ b/programs/piaware/Makefile
@@ -3,9 +3,8 @@
 # FA's simple aviation data exchange protocol
 #
 
-LIB=/usr/lib
-BIN=/usr/bin
-TCLSH=tclsh8.5
+LIB=$(PREFIX_DIR)/lib
+BIN=$(PREFIX_DIR)/bin
 
 CLIENT_INSTALLFILES= *.tcl
 

--- a/programs/piaware/helpers.tcl
+++ b/programs/piaware/helpers.tcl
@@ -12,6 +12,10 @@ package require tls
 proc logger {text} {
 	#::bsd::syslog log info $text
 	log_locally $text
+	if {[llength [info commands "adept"]] < 1} {
+	     # adept client has not yet loaded
+	     return 0
+	}
 	adept send_log_message $text
 }
 


### PR DESCRIPTION
piaware by default installs to a hardcoded directory with no control over location. This patch lets you specify the base directory for installation, instead of /usr  such that custom installation prefixes can be used for fakeroot/packaging purposes.