### PR TITLE
Pass --numeric to netstat so it doesn't hang on slow DNS.

### DIFF
--- a/package/piaware.tcl
+++ b/package/piaware.tcl
@@ -173,12 +173,12 @@ proc process_netstat_socket_line {line} {
     lassign $line proto recvq sendq localAddress foreignAddress state pidProg
     lassign [split $pidProg "/"] pid prog
 
-    if {($localAddress == "*:30005" || $localAddress == "localhost:30005") && $state == "LISTEN"} {
+    if {[string match "*:30005" $localAddress] && $state == "LISTEN"} {
 		set ::netstatus(program_30005) $prog
 		set ::netstatus(status_30005) 1
     }
 
-    if {($localAddress == "*:10001" || $localAddress == "localhost:10001") && $state == "LISTEN"} {
+    if {[string match "*:10001" $localAddress] && $state == "LISTEN"} {
 		set ::netstatus(program_10001) $prog
 		set ::netstatus(status_10001) 1
     }
@@ -186,18 +186,18 @@ proc process_netstat_socket_line {line} {
 
     switch $prog {
 		"faup1090" {
-			if {$foreignAddress == "localhost:30005" && $state == "ESTABLISHED"} {
+			if {[string match "*:30005" $foreignAddress] && $state == "ESTABLISHED"} {
 				set ::netstatus(faup1090_30005) 1
 			}
 		}
 
 		"piaware" {
 			set ::running(piaware) 1
-			if {$foreignAddress == "localhost:10001" && $state == "ESTABLISHED"} {
+			if {[string match "*:10001" $foreignAddress] && $state == "ESTABLISHED"} {
 				set ::netstatus(piaware_10001) 1
 			}
 
-			if {$foreignAddress == "eyes.flightaware.com:1200" && $state == "ESTABLISHED"} {
+			if {[string match "*:1200" $foreignAddress] && $state == "ESTABLISHED"} {
 				set ::netstatus(piaware_1200) 1
 			}
 		}
@@ -217,7 +217,7 @@ proc inspect_sockets_with_netstat {} {
     set ::netstatus(piaware_10001) 0
     set ::netstatus(piaware_1200) 0
 
-    set fp [open "|netstat --program --protocol=inet --tcp --wide --all"]
+    set fp [open "|netstat --program --protocol=inet --tcp --wide --all --numeric"]
     # discard two header lines
     gets $fp
     gets $fp


### PR DESCRIPTION
(Also happens to futureproof against using a different adept server host)