### PR TITLE
Added constraints for picking dump1090 init script

### DIFF
--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -408,39 +408,37 @@ proc stop_faup1090_close_faup1090_socket_and_reopen {} {
 proc attempt_dump1090_restart {{action restart}} {
 	set scripts [glob -nocomplain /etc/init.d/*dump1090*]
 
-	switch [llength $scripts] {
-		0 {
-			logger "can't $action dump1090, no dump1090 script in /etc/init.d"
-			return
-		}
-
-		1 {
-			set script [lindex $scripts 0]
-		}
-
-		default {
-			foreach script $scripts {
-				if {[string match "*old*" $script]} continue
-
-				if {[string match "fadump1090*" $script]} {
-					set scripts $script
-					break
-				}
-			}
-			if {[llength $scripts] > 1} {
-				set scripts [lindex $scripts 0]
-			}
-			logger "warning, more than one dump1090 script in /etc/init.d, proceeding with '$script'..."
+	foreach script $scripts {
+		switch -glob $script {
+			*\.dpkg*	{ 
+			} *\.rpm*	{
+			} *\.ba*	{
+			} *\.old	{ 
+			} *\.org	{
+			} *\.orig	{
+			} *\.save	{
+			} *\.swp	{
+			} *\.core	{ 
+			} default	{ lappend acceptableScripts $script
+			}	
 		}
 	}
+	if { [info exists acceptableScripts] } {
+		set script [lindex $acceptableScripts 0]
+		if { [llength $acceptableScripts] > 1 } {
+			logger "warning, more than one dump1090 script in /etc/init.d, proceding with '$script'..."
+		}
 
-	logger "attempting to $action dump1090 using '$script $action'..."
-	set exitStatus [system "$script $action"]
+		logger "attempting to $action dump1090 using '$script $action'..."
+		set exitStatus [system "$script $action"]
 
-	if {$exitStatus == 0} {
-		logger "dump1090 $action appears to have been successful"
-	} else {
-		logger "got exit status $exitStatus while trying to $action dump1090"
+		if {$exitStatus == 0} {
+			logger "dump1090 $action appears to have been successful"
+		} else {
+			logger "got exit status $exitStatus while trying to $action dump1090"
+		}
+	} else { 
+		logger "can't $action dump1090, no dump1090 script in /etc/init.d"
 	}
 }
 

--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -410,17 +410,24 @@ proc attempt_dump1090_restart {{action restart}} {
 
 	foreach script $scripts {
 		switch -glob $script {
-			*\.dpkg*	{ 
-			} *\.rpm*	{
-			} *\.ba*	{
-			} *\.old	{ 
-			} *\.org	{
-			} *\.orig	{
-			} *\.save	{
-			} *\.swp	{
-			} *\.core	{ 
-			} default	{ lappend acceptableScripts $script
-			}	
+			*.dpkg*	-
+			*.rpm* -
+			*.ba* -
+			*.old -
+			*.org -
+			*.orig -
+			*.save -
+			*.swp -
+			*.core -
+			*~ {
+				# Skip this
+			}
+
+			default {
+				if {[auto_execok $script] ne ""} {
+					lappend acceptableScripts $script
+				}
+			}
 		}
 	}
 	if { [info exists acceptableScripts] } {


### PR DESCRIPTION
I removed the preference for fadump1090, but can add back in if we still want it. Tested for cases where there was no valid dump1090 in init.d, as well as valid and invalid dump1090 files (e.g. dump1090.orig). 

In the case of more than one valid dump1090 init script, do we want to try to figure out what our preference is, or just take the first one?