### PR TITLE
Block weak DH ciphers which cause TLS negotation to fail

### DIFF
--- a/package/fa_adept_client.tcl
+++ b/package/fa_adept_client.tcl
@@ -95,7 +95,7 @@ namespace eval ::fa_adept {
 		# CA cert file to confirm the cert's signature on the certificate
 		# the server sends us
 		if {[catch {set sock [tls::socket \
-			-cipher ALL \
+			-cipher DEFAULT:!EDH \
 			-cafile [::fa_adept::ca_crt_file] \
 			-ssl2 0 \
 			-ssl3 0 \

--- a/package/piaware.tcl
+++ b/package/piaware.tcl
@@ -527,7 +527,7 @@ proc init_http_client {} {
 		return
     }
 
-    ::tls::init -ssl2 0 -ssl3 0 -tls1 1
+    ::tls::init -ssl2 0 -ssl3 0 -tls1 1 -cipher DEFAULT:!EDH
     ::http::register https 443 ::tls::socket
 
     set ::tlsInitialized 1


### PR DESCRIPTION
The FA servers currently return 512 bit DH keys which are being
rejected by the latest OpenSSL code due to CVE-2015-4000.
Removing these ciphers allows the client to connect successfully
using non-DH ciphers.