### PR TITLE
Disabling default loopback of MLAT data to local Dump1090

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,21 @@ there's a process for claiming a PiAware receiver as belonging to you.  For more
 [PiAware build instructions](https://flightaware.com/adsb/piaware/build) at FlightAware.
 
 piaware-config may also be used to configure where multilateration results are forwarded. By default, results will be
-looped back to the local dump1090 process on port 30004. This can be disabled if needed:
+made available on port 31003 in Basestation format.  This is different to the previous default of automatically looping back to the local dump1090 process on port 30004.  This is to avoid causing issues for clients feeding other sites and clients which do not expect or are unable to distinguish non-aircraft derived messages and interpret FlightAware MLAT calulated positions as true ADS-B data.
 
-```
-$ sudo piaware-config -mlatResults 0
-```
-
-Or the ways in which results are generated can be modified:
+If the previous behaviour is required, it must be explicitly enabled.  However, before doing so, you must ensure that any other clients using the local dump1090 can handle and are happy to accept MLAT data:
 
 ```
   # Connect to localhost:30004 and send multilateration results in Beast format.
   # Listen on port 310003 and provide multilateration results in Basestation format to anyone who connects
 
 $ sudo piaware-config -mlatResultsFormat "beast,connect,localhost:30004 basestation,listen,31003"
+```
+
+Feedback of MLAT results can be disabled entirely if needed:
+
+```
+$ sudo piaware-config -mlatResults 0
 ```
 
 piaware-status program

--- a/programs/piaware/mlat.tcl
+++ b/programs/piaware/mlat.tcl
@@ -111,7 +111,7 @@ proc start_mlat_client {} {
 
 	if {![info exists ::adeptConfig(mlatResults)] || ([string is boolean $::adeptConfig(mlatResults)] && $::adeptConfig(mlatResults))} {
 		if {![info exists ::adeptConfig(mlatResultsFormat)] || $::adeptConfig(mlatResultsFormat) eq "default"} {
-			lappend command "--results" "beast,connect,localhost:30004"
+			lappend command "--results" "basestation,listen,31003"
 		} else {
 			foreach r $::adeptConfig(mlatResultsFormat) {
 				lappend command "--results" $r


### PR DESCRIPTION
Suggest changing the default behaviour of PiAware to prevent FlightAware calculated MLAT data being fed back to Dump1090 and inadvertently upstream to other clients that a user has which are unable to distinguish MLAT data from true aircraft-derived ADS-B positions, such as FlightRadar24.
In my opinion, loopback of MLAT data should be an opt-in feature with appropriate guidelines and checks in place to make sure that a user enabling it knows what they're doing.
With RPi clients on both FlightAware and FlightRadar24, a growing number of feeders want and are able to supply both.  However, default behaviour of the FA feeder software is effectively contaminating FR24 with non-ADS-B data.
It may be considered that it is their problem rather than FlightAware's, and it's true that spoofing and MLAT-checks should be stronger, but there's no harm in helping to prevent giving away hard-won and calculated MLAT data straight into another site!