### PR TITLE
Prevent piaware from writing new locations every time location changes due to GPS jitter

### DIFF
--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -396,7 +396,7 @@ proc update_location {lat lon} {
 
 	if {$::receiverLat ne "" && $::receiverLon ne ""} {
 		if {abs($::receiverLat - $lat) < 0.1 && abs($::receiverLon - $lon) < 0.1} {
-			# Didn't change enough to care about saving location/restarting
+			# Didn't change enough to care about restarting
 			return
 		}
 	}

--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -381,11 +381,9 @@ proc traffic_report {} {
 # when adept tells us the receiver location,
 # record it and maybe restart dump1090 / faup1090
 proc update_location {lat lon} {
-	if {$::receiverLat ne "" && $::receiverLon ne ""} {
-		if {abs($::receiverLat - $lat) < 0.1 && abs($::receiverLon - $lon) < 0.1} {
-			# Didn't change enough to care about saving location/restarting
-			return
-		}
+	if {$lat eq $::receiverLat && $lon eq $::receiverLon} {
+		# unchanged
+		return
 	}
 
 	# nb: we always save the new location, but the globals
@@ -396,6 +394,12 @@ proc update_location {lat lon} {
 
 	set saved [save_location_info $lat $lon]
 
+	if {$::receiverLat ne "" && $::receiverLon ne ""} {
+		if {abs($::receiverLat - $lat) < 0.1 && abs($::receiverLon - $lon) < 0.1} {
+			# Didn't change enough to care about saving location/restarting
+			return
+		}
+	}
 
 	# changed nontrivially; restart faup1090 to use the new values
 	set ::receiverLat $lat

--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -381,9 +381,11 @@ proc traffic_report {} {
 # when adept tells us the receiver location,
 # record it and maybe restart dump1090 / faup1090
 proc update_location {lat lon} {
-	if {$lat eq $::receiverLat && $lon eq $::receiverLon} {
-		# unchanged
-		return
+	if {$::receiverLat ne "" && $::receiverLon ne ""} {
+		if {abs($::receiverLat - $lat) < 0.1 && abs($::receiverLon - $lon) < 0.1} {
+			# Didn't change enough to care about saving location/restarting
+			return
+		}
 	}
 
 	# nb: we always save the new location, but the globals
@@ -394,12 +396,6 @@ proc update_location {lat lon} {
 
 	set saved [save_location_info $lat $lon]
 
-	if {$::receiverLat ne "" && $::receiverLon ne ""} {
-		if {abs($::receiverLat - $lat) < 0.1 && abs($::receiverLon - $lon) < 0.1} {
-			# Didn't change enough to care about restarting
-			return
-		}
-	}
 
 	# changed nontrivially; restart faup1090 to use the new values
 	set ::receiverLat $lat

--- a/programs/piaware/health.tcl
+++ b/programs/piaware/health.tcl
@@ -117,6 +117,18 @@ proc location_data_changed {} {
 
 	# record the location and maybe restart faup1090 with the new value
 	lassign $newloc lat lon alt altref
+
+	# if we recieve new location from gpsd, only update location if moved a signifcant amount to avoid writing everytime location has changed due to gps jitter
+	if {$src eq "gpsd"} {
+		set last [adept last_reported_location]
+		if {$last ne ""} {
+			lassign $last lastLat lastLon lastAlt lastAltref
+			if {abs($lat - $lastLat) < 0.0001 && abs($lon - $lastLon) < 0.0001} {
+				return
+			}
+		}
+	}
+
 	update_location $lat $lon
 
 	# tell adept about the new location


### PR DESCRIPTION
Currently piaware rewrites location file if any change in location at all. Add some logic to handle GPS modules that may cause frequent, but insignificant changes in location. 

Range currently set at 0.0001 lat/lon but can be changed as needed