### PR TITLE
[WIP] Create Itcl class for faup program connections

### DIFF
--- a/programs/piaware/faup.tcl
+++ b/programs/piaware/faup.tcl
@@ -1,0 +1,159 @@
+# -*- mode: tcl; tab-width: 4; indent-tabs-mode: t -*-
+
+package require Itcl 3.4
+
+#
+# Class that handles connection between faup programs and adept
+#
+::itcl::class FaupConnection {
+	# faup program this connection is receving data from (faup1090, faup978, etc.)
+	public variable receiverType
+	public variable receiverHost
+	public variable receiverPort
+	public variable receiverLat
+	public variable receiverLon
+	public variable receiverDataFormat
+	public variable adsbLocalPort
+	public variable adsbDataService
+	public variable adsbDataProgram
+	public variable faupProgramPath
+
+	# total message from faup program
+	private variable nfaupMessagesReceived
+	# number of message from faup program since we last logged about is
+	private variable nfaupMessagesThisPeriod
+	# total messages sent to adept
+	private variable nMessagesSent
+	# last time we considered (re)starting faup program
+	private variable lastConnectAttemptClock
+	# time of the last message from faup program
+	private variable lastFaupMessageClock
+	# time we were last connected to data port
+	private variable lastAdsbConnectedClock
+	# last banner tsv_version we saw - REVISIT!
+	#private variable tsvVersion ""
+	# timer to start faup program connection
+	private variable adsbPortConnectTimer
+
+	private variable faupPipe
+	private variable faupPid
+
+	constructor {args} {
+		configure {*}$args
+	}
+
+	destructor {
+		disconnect
+	}
+
+	#
+	# Connect to faup program and configure channel
+	#
+        method connect {} {
+		unset -nocomplain adsbPortConnectTimer
+
+		# just in case..
+		disconnect
+
+		set lastConnectAttemptClock [clock seconds]
+
+		set args $faupProgramPath
+		lappend args "--net-bo-ipaddr" $receiverHost "--net-bo-port" $receiverPort "--stdout"
+		if {$receiverLat ne "" && $receiverLon ne ""} {
+			lappend args "--lat" [format "%.3f" $receiverLat] "--lon" [format "%.3f" $receiverLon]
+		}
+
+		logger "Starting $this: $args"
+
+		if {[catch {::fa_sudo::popen_as -noroot -stdout faupStdout -stderr faupStderr {*}$args} result] == 1} {
+			logger "got '$result' starting $this, will try again in 5 minutes"
+			#schedule_adsb_connect_attempt 300
+			return
+		}
+
+		if {$result == 0} {
+			logger "could not start $this: sudo refused to start the command, will try again in 5 minutes"
+			#schedule_adsb_connect_attempt 300
+			return
+		}
+
+
+		logger "Started $this (pid $result) to connect to $adsbDataProgram"
+		fconfigure $faupStdout -buffering line -blocking 0 -translation lf
+		fileevent $faupStdout readable [list $this data_available]
+
+		log_subprocess_output "${this}($result)" $faupStderr
+
+		set faupPipe $faupStdout
+		set faupPid $result
+
+		# pretend we saw a message so we don't repeatedly restart
+		set lastFaupMessageClock [clock seconds]
+
+        }
+
+	#
+	# clean up faup pipe, don't schedule a reconnect
+	#
+	method disconnect {} {
+		if {![info exists faupPipe]} {
+                        # nothing to do.
+                        return
+                }
+
+                # record when we were last connected
+                set lastAdsbConnectedClock [clock seconds]
+                catch {kill HUP $faupPid}
+                catch {close $faupPipe}
+
+                catch {
+                        lassign [timed_waitpid 15000 $faupPid] deadpid why code
+                        if {$code ne "0"} {
+                                logger "$this exited with $why $code"
+                        } else {
+                                logger "$this exited normally"
+                        }
+                }
+
+                unset faupPipe
+                unset faupPid
+	}
+
+	#
+	# filevent callback routine when data available on socket
+	#
+	method data_available {} {
+		# if eof, cleanly close the faup socket and reconnect...
+		if {[eof $faupPipe]} {
+			logger "lost connection to $adsbDataProgram via $this"
+			# todo: implement restart_faup1090
+			disconnect
+			return
+		}
+
+		# try to read, if that fails, disconnect and reconnect...
+		if {[catch {set size [gets $faupPipe line]} catchResult] == 1} {
+			logger "got '$catchResult' reading from $this"
+			#todo: implement restart_faup1090
+			disconnect
+			return
+		}
+
+		# sometimes you can get a notice of data available and not get any data.
+		# it happens.  nothing to do? return.
+		if {$size < 0} {
+			return
+		}
+
+		incr nfaupMessagesReceived
+		incr nfaupMessagesThisPeriod
+		if {$nfaupMessagesReceived  == 1} {
+			log_locally "piaware received a message from $adsbDataProgram!"
+		}
+
+		# TODO : PROCESS 1090 VS 978 MESSAGE APPROPRIATELY AND SEND TO ADEPT/PIREHOSE
+		puts $line
+
+		set lastFaupMessageClock [clock seconds]
+	}
+}

--- a/programs/piaware/faup.tcl
+++ b/programs/piaware/faup.tcl
@@ -45,6 +45,7 @@ package require Itcl 3.4
 
 	destructor {
 		faup_disconnect
+		::itcl::delete object $this
 	}
 
 	#

--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -12,21 +12,6 @@ package require fa_services
 # setup_faup1090_vars - setup vars but don't start faup1090
 #
 proc setup_faup1090_vars {} {
-	# total message from faup1090
-	set ::nfaupMessagesReceived 0
-	# number of message from faup1090 since we last logged about is
-	set ::nfaupMessagesThisPeriod 0
-	# total messages sent to adept
-	set ::nMessagesSent 0
-	# last time we considered (re)starting faup1090
-	set ::lastConnectAttemptClock 0
-	# time of the last message from faup1090
-	set ::lastFaupMessageClock [clock seconds]
-	# time we were last connected to port 30005
-	set ::lastAdsbConnectedClock [clock seconds]
-	# last banner tsv_version we saw
-	set ::tsvVersion ""
-
 	# receiver config
 	set ::receiverType [piawareConfig get receiver-type]
 	lassign [receiver_host_and_port piawareConfig] ::receiverHost ::receiverPort
@@ -43,281 +28,54 @@ proc setup_faup1090_vars {} {
 	}
 }
 
-proc is_local_receiver {} {
-	return [expr {$::adsbLocalPort ne 0}]
-}
-
-#
-# is_adsb_program_running - return 1 if the adsb program (probably dump1090)
-# is running, else 0
-#
-proc is_adsb_program_running {} {
-	if {![is_local_receiver]} {
-		# not local, assume yes
-		return 1
-	}
-
-	return [info exists ::netstatus($::adsbLocalPort)]
-}
-
-proc adsb_local_program_name {} {
-	if {![is_local_receiver]} {
-		return ""
-	}
-
-	if {![info exists ::netstatus($::adsbLocalPort)]} {
-		return ""
-	}
-
-	lassign $::netstatus($::adsbLocalPort) prog pid
-	if {$prog eq "unknown"} {
-		return ""
-	}
-
-	return $prog
-}
-
-#
-# schedule_adsb_connect_attempt - schedule an attempt to connect
-#  to the ADS-B port canceling the prior one if one was already scheduled
-#
-# support "idle" as an argument to do "after idle" else a number of seconds
-#
-proc schedule_adsb_connect_attempt {inSeconds} {
-	if {[info exists ::adsbPortConnectTimer]} {
-		after cancel $::adsbPortConnectTimer
-		#logger "canceled prior adsb port connect attempt timer $::adsbPortConnectTimer"
-	}
-
-	if {$inSeconds == "idle"} {
-		set ms "idle"
-		set explain "when idle"
-	} elseif {[string is integer -strict $inSeconds]} {
-		set ms [expr {$inSeconds * 1000}]
-		set explain "in $inSeconds seconds"
-	} else {
-		error "argument must be an integer or 'idle'"
-	}
-
-	set ::adsbPortConnectTimer [after $ms connect_adsb_via_faup1090]
-	#logger "scheduled FA-style ADS-B port connect attempt $explain as timer ID $::adsbPortConnectTimer"
-}
-
 #
 # connect_adsb_via_faup1090 - connect to the receiver using faup1090 as an intermediary;
 # if it fails, schedule another attempt later
 #
 proc connect_adsb_via_faup1090 {} {
-	unset -nocomplain ::adsbPortConnectTimer
-
-	# just in case..
-	stop_faup1090
-
-	set ::lastConnectAttemptClock [clock seconds]
-
-	if {[is_local_receiver]} {
-		inspect_sockets_with_netstat
-
-		if {$::netstatus_reliable && ![is_adsb_program_running]} {
-			# still no listener, consider restarting
-			set secondsSinceListenerSeen [expr {[clock seconds] - $::lastAdsbConnectedClock}]
-			if {$secondsSinceListenerSeen >= $::adsbNoProducerStartDelaySeconds && $::adsbDataService ne ""} {
-				logger "no ADS-B data program seen listening on port $::adsbLocalPort for $secondsSinceListenerSeen seconds, trying to start it..."
-				::fa_services::attempt_service_restart $::adsbDataService start
-				# pretend we saw it to reduce restarts if it's failing
-				set ::lastAdsbConnectedClock [clock seconds]
-				schedule_adsb_connect_attempt 10
-			} else {
-				logger "no ADS-B data program seen listening on port $::adsbLocalPort for $secondsSinceListenerSeen seconds, next check in 60s"
-				schedule_adsb_connect_attempt 60
-			}
-
-			return
-		}
-
-		set prog [adsb_local_program_name]
-		if {$prog ne ""} {
-			set ::adsbDataProgram $prog
-		}
-		set ::lastAdsbConnectedClock [clock seconds]
-		logger "ADS-B data program '$::adsbDataProgram' is listening on port $::adsbLocalPort, so far so good"
+	# stop faup1090 connection just in case...
+	if {[info exists ::faup1090]} {
+		$::faup1090 faup_disconnect
 	}
 
-	set args $::faup1090Path
-	lappend args "--net-bo-ipaddr" $::receiverHost "--net-bo-port" $::receiverPort "--stdout"
-	if {$::receiverLat ne "" && $::receiverLon ne ""} {
-		lappend args "--lat" [format "%.3f" $::receiverLat] "--lon" [format "%.3f" $::receiverLon]
-	}
+	# Create faup connection object with receiver config
+	set ::faup1090 [FaupConnection faup1090 \
+		-adsbDataProgram $::adsbDataProgram \
+		-receiverType $::receiverType \
+		-receiverHost $::receiverHost \
+		-receiverPort $::receiverPort \
+		-receiverLat $::receiverLat \
+		-receiverLon $::receiverLon \
+		-receiverDataFormat $::receiverDataFormat \
+		-adsbLocalPort $::adsbLocalPort \
+		-adsbDataService $::adsbDataService \
+		-faupProgramPath $::faup1090Path]
 
-	logger "Starting faup1090: $args"
-
-	if {[catch {::fa_sudo::popen_as -noroot -stdout faupStdout -stderr faupStderr {*}$args} result] == 1} {
-		logger "got '$result' starting faup1090, will try again in 5 minutes"
-		schedule_adsb_connect_attempt 300
-		return
-	}
-
-	if {$result == 0} {
-		logger "could not start faup1090: sudo refused to start the command, will try again in 5 minutes"
-		schedule_adsb_connect_attempt 300
-		return
-	}
-
-
-	logger "Started faup1090 (pid $result) to connect to $::adsbDataProgram"
-	fconfigure $faupStdout -buffering line -blocking 0 -translation lf
-	fileevent $faupStdout readable faup1090_data_available
-
-	log_subprocess_output "faup1090($result)" $faupStderr
-
-	set ::faupPipe $faupStdout
-	set ::faupPid $result
-
-	# pretend we saw a message so we don't repeatedly restart
-	set ::lastFaupMessageClock [clock seconds]
+	$::faup1090 faup_connect
 }
 
 #
 # stop_faup1090 - clean up faup1090 pipe, don't schedule a reconnect
 #
 proc stop_faup1090 {} {
-	if {![info exists ::faupPipe]} {
-		# nothing to do.
+	if {![info exists ::faup1090]} {
+		# Nothing to do
 		return
 	}
 
-	# record when we were last connected
-	set ::lastAdsbConnectedClock [clock seconds]
-	catch {kill HUP $::faupPid}
-	catch {close $::faupPipe}
-
-	catch {
-		lassign [timed_waitpid 15000 $::faupPid] deadpid why code
-		if {$code ne "0"} {
-			logger "faup1090 exited with $why $code"
-		} else {
-			logger "faup1090 exited normally"
-		}
-	}
-
-	unset ::faupPipe
-	unset ::faupPid
+	$::faup1090 faup_disconnect
 }
 
 #
 # restart_faup1090 - pretty self-explanatory
 #
 proc restart_faup1090 {{delay 30}} {
-	stop_faup1090
-
-	if {$delay eq "now" || [clock seconds] - $::lastConnectAttemptClock > $delay} {
-		logger "reconnecting to $::adsbDataProgram"
-		schedule_adsb_connect_attempt 1
+	if {![info exists ::faup1090]} {
+		# Nothing to do
 		return
 	}
 
-	logger "will reconnect to $::adsbDataProgram in $delay seconds"
-	schedule_adsb_connect_attempt $delay
-}
-
-#
-# faup1090_data_available - callback routine when data is available from the
-#  socket to faup1090
-#
-proc faup1090_data_available {} {
-	# if eof, cleanly close the faup1090 socket and reconnect...
-    if {[eof $::faupPipe]} {
-		logger "lost connection to $::adsbDataProgram via faup1090"
-		restart_faup1090
-		return
-    }
-
-	# try to read, if that fails, disconnect and reconnect...
-    if {[catch {set size [gets $::faupPipe line]} catchResult] == 1} {
-		logger "got '$catchResult' reading from faup1090"
-		restart_faup1090
-		return
-    }
-
-	# sometimes you can get a notice of data available and not get any data.
-	# it happens.  nothing to do? return.
-    if {$size < 0} {
-		return
-    }
-
-	incr ::nfaupMessagesReceived
-	incr ::nfaupMessagesThisPeriod
-	if {$::nfaupMessagesReceived == 1} {
-		log_locally "piaware received a message from $::adsbDataProgram!"
-	}
-
-	array set row [split $line "\t"]
-	if {[info exists row(type)] && $row(type) eq "location_update"} {
-		# we handle this directly
-		handle_location_update "receiver" $row(lat) $row(lon) $row(alt) $row(altref)
-		return
-	}
-
-	# remember tsv_version when seen
-	if {[info exists row(tsv_version)]} {
-		set ::tsvVersion $row(tsv_version)
-	}
-
-    #puts "faup1090 data: $line"
-	# if logged into flightaware adept, send the data
-	send_if_logged_in row
-
-	# also forward to pirehose, if running
-	forward_to_pirehose $line
-
-	set ::lastFaupMessageClock [clock seconds]
-}
-
-#
-# send_if_logged_in - send an adept message but only if logged in
-#
-proc send_if_logged_in {_row} {
-	upvar $_row row
-
-    if {![adept is_logged_in]} {
-		return
-    }
-
-	if {[catch {send_adsb_line row} catchResult] == 1} {
-		log_locally "error uploading ADS-B message: $catchResult"
-	}
-}
-
-#
-# send_adsb_line - send an ADS-B message to the adept server
-#
-proc send_adsb_line {_row} {
-	upvar $_row row
-
-	# extra filtering to avoid looping mlat results back
-	if {[info exists row(hexid)]} {
-		set hexid $row(hexid)
-		if {[info exists ::mlatSawResult($hexid)]} {
-			if {($row(clock) - $::mlatSawResult($row(hexid))) < 45.0} {
-				foreach field {alt alt_gnss vrate vrate_geom position track speed} {
-					if {[info exists row($field)]} {
-						lassign $row($field) value age src
-						if {$src eq "A"} {
-							# This is suspect, claims to be ADS-B while we're doing mlat, clear it.
-							unset -nocomplain row($field)
-						}
-					}
-				}
-			}
-		}
-	}
-
-	adept send_array row
-
-	incr ::nMessagesSent
-	if {$::nMessagesSent == 7} {
-		log_locally "piaware has successfully sent several msgs to FlightAware!"
-	}
+	$::faup1090 faup_restart $delay
 }
 
 #
@@ -327,94 +85,25 @@ proc send_adsb_line {_row} {
 # also issue a traffic report
 #
 proc periodically_check_adsb_traffic {} {
+	if {![info exists ::faup1090]} {
+		return
+	}
+
 	after [expr {$::adsbTrafficCheckIntervalSeconds * 1000}] periodically_check_adsb_traffic
 
-	check_adsb_traffic
+	$::faup1090 check_traffic
 
-	after 30000 traffic_report
-}
-
-#
-# check_adsb_traffic - see if ADS-B messages are being received.
-# restart stuff as necessary
-#
-proc check_adsb_traffic {} {
-	set secondsSinceLastMessage [expr {[clock seconds] - $::lastFaupMessageClock}]
-
-	if {[info exists ::faupPipe]} {
-		# faup1090 is running, check we are hearing some messages
-		if {$secondsSinceLastMessage >= $::noMessageActionIntervalSeconds} {
-			# force a restart
-			logger "no new messages received in $secondsSinceLastMessage seconds, it might just be that there haven't been any aircraft nearby but I'm going to try to restart everything, just in case..."
-			stop_faup1090
-			if {$::adsbDataService ne ""} {
-				::fa_services::attempt_service_restart $::adsbDataService restart
-			}
-			schedule_adsb_connect_attempt 10
-		}
-	} else {
-		if {![info exists ::adsbPortConnectTimer]} {
-			# faup1090 not running and no timer set! Bad doggie.
-			logger "faup1090 not running, but no restart timer set! Fixing it.."
-			schedule_adsb_connect_attempt 5
-		}
-	}
-}
-
-#
-# traffic_report - log a traffic report of messages received from the adsb
-#   program and messages sent to FlightAware
-#
-proc traffic_report {} {
-	set periodString ""
-	if {[info exists ::faupMessagesPeriodStartClock]} {
-		set minutesThisPeriod [expr {round(([clock seconds] - $::faupMessagesPeriodStartClock) / 60.0)}]
-		set periodString " ($::nfaupMessagesThisPeriod in last ${minutesThisPeriod}m)"
-	}
-	set ::faupMessagesPeriodStartClock [clock seconds]
-	set ::nfaupMessagesThisPeriod 0
-
-	logger "$::nfaupMessagesReceived msgs recv'd from $::adsbDataProgram$periodString; $::nMessagesSent msgs sent to FlightAware"
-
+	after 30000 $::faup1090 traffic_report
 }
 
 # when adept tells us the receiver location,
 # record it and maybe restart dump1090 / faup1090
 proc update_location {lat lon} {
-	if {$lat eq $::receiverLat && $lon eq $::receiverLon} {
-		# unchanged
+	if {![info exists ::faup1090]} {
 		return
 	}
 
-	# only update the on-disk location & restart things
-	# if the location moves by more than about 250m since
-	# the last time we updated
-
-	if {$::receiverLat ne "" && $::receiverLon ne ""} {
-		# approx distances in km along lat/lon axes, don't bother with the full GC distance
-		set dLat [expr {111 * ($::receiverLat - $lat)}]
-		set dLon [expr {111 * ($::receiverLon - $lon) * cos($lat * 3.1415927 / 180.0)}]
-		if {abs($dLat) < 0.250 && abs($dLon) < 0.250} {
-			# Didn't change enough to care about restarting
-			return
-		}
-	}
-
-	# changed nontrivially; restart dump1090 / faup1090 to use the new values
-	set ::receiverLat $lat
-	set ::receiverLon $lon
-
-	# speculatively restart dump1090 even if we are not using it as a receiver;
-	# it may be used for display.
-	if {[save_location_info $lat $lon]} {
-		logger "Receiver location changed, restarting dump1090"
-		::fa_services::attempt_service_restart dump1090 restart
-	}
-
-	if {[info exists ::faupPipe]} {
-		logger "Receiver location changed, restarting faup1090"
-		restart_faup1090 5
-	}
+	$::faup1090 update_location $lat $lon
 }
 
 # vim: set ts=4 sw=4 sts=4 noet :

--- a/programs/piaware/login.tcl
+++ b/programs/piaware/login.tcl
@@ -122,9 +122,9 @@ proc handle_login_result {data} {
 		# (we do this here, not in the login message, to avoid a race
 		# between faup1090 producing tsv_version for the first time
 		# and the login response arriving)
-		if {$::tsvVersion ne ""} {
+		if {[info exists ::faup1090] && [set tsvVersion [$::faup1090 get_tsv_version]] ne ""} {
 			set header(clock) [clock seconds]
-			set header(tsv_version) $::tsvVersion
+			set header(tsv_version) $tsvVersion
 			adept send_array header
 		}
 	} else {

--- a/programs/piaware/main.tcl
+++ b/programs/piaware/main.tcl
@@ -28,6 +28,7 @@ source $::launchdir/pirehose.tcl
 source $::launchdir/update.tcl
 source $::launchdir/login.tcl
 source $::launchdir/statusfile.tcl
+source $::launchdir/faup.tcl
 
 #
 # main - the main program

--- a/programs/piaware/mlat.tcl
+++ b/programs/piaware/mlat.tcl
@@ -114,10 +114,10 @@ proc start_mlat_client {} {
 		return
 	}
 
-	if {[is_local_receiver]} {
+	if {[is_local_receiver $::adsbLocalPort]} {
 		inspect_sockets_with_netstat
 
-		if {![is_adsb_program_running]} {
+		if {![is_adsb_program_running $::adsbLocalPort]} {
 			logger "no ADS-B data program is serving on port $::adsbLocalPort, not starting multilateration client yet"
 			schedule_mlat_client_restart
 			return

--- a/programs/piaware/statusfile.tcl
+++ b/programs/piaware/statusfile.tcl
@@ -84,8 +84,8 @@ proc build_status {} {
 	}
 
 	# radio: status of the connection to the receiver process
-	if {[info exists ::faupPid]} {
-		if {([clock seconds] - $::lastFaupMessageClock) < 60} {
+	if {[info exists ::faup1090] && [$::faup1090 is_connected]} {
+		if {([clock seconds] - [$::faup1090 last_message_received]) < 60} {
 			set data(radio) [status_entry "green" "Received Mode S data recently"]
 		} else {
 			set data(radio) [status_entry "amber" "Connected to receiver, but no recent data seen"]


### PR DESCRIPTION
Opening PR to get eyes on the work in progress

This PR is a Itcl class definition for faup program connections. The idea is to be able to start/connect to an faup program (faup1090, faup978, etc.) by instantiating a FaupConnection instance with the appropriate receiver arguments. 

The changes are mainly just refactoring of the existing faup1090.tcl and modifying method input parameters and global variable declarations within the class. 

Regression testing looks good so far:
1. Receiving data from dump1090-fa and uploading to FA
2. Restart paths (dump1090-fa hosed, no data seen, etc.)
3. Location updates

Next changes will be handling of 1090 vs 978 messages (using separate handlers or subclasses TBD)