### PR TITLE
Require Itcl 3.4.

### DIFF
--- a/package/fa_adept_client.tcl
+++ b/package/fa_adept_client.tcl
@@ -9,7 +9,7 @@
 #
 
 package require tls
-package require Itcl
+package require Itcl 3.4
 package require fa_adept_codecs 2.1
 
 namespace eval ::fa_adept {

--- a/package/fa_gps.tcl
+++ b/package/fa_gps.tcl
@@ -7,7 +7,7 @@
 # open source in accordance with the Berkeley license
 #
 
-package require Itcl
+package require Itcl 3.4
 package require json
 
 namespace eval ::fa_gps {

--- a/package/fa_piaware_config.tcl
+++ b/package/fa_piaware_config.tcl
@@ -7,7 +7,7 @@
 #
 #
 
-package require Itcl
+package require Itcl 3.4
 package require tryfinallyshim
 package require fa_sudo
 package require Tclx

--- a/package/piaware.tcl
+++ b/package/piaware.tcl
@@ -7,7 +7,7 @@
 
 package require http
 package require tls
-package require Itcl
+package require Itcl 3.4
 package require tryfinallyshim
 package require fa_sudo
 


### PR DESCRIPTION
Make sure to require Itcl version 3.4 else piaware will fail to start if 3.4 and another version is present.

> 
> `# piaware
> version conflict for package "Itcl": have 4.1.2, need 3.4
>     while executing
> "package require Itcl 3.4"
>     (file "/usr/lib/piaware/faup.tcl" line 3)
>     invoked from within
> "source $::launchdir/faup.tcl"
>     (file "/usr/lib/piaware/main.tcl" line 24)
>     invoked from within
> "source /usr/lib/piaware/main.tcl"
>     ("uplevel" body line 1)
>     invoked from within
> "uplevel #0 source $path"`