### PR TITLE
Use saved location on faup1090 restarts

### DIFF
--- a/programs/piaware/faup.tcl
+++ b/programs/piaware/faup.tcl
@@ -10,8 +10,6 @@ package require Itcl
 	public variable receiverType
 	public variable receiverHost
 	public variable receiverPort
-	public variable receiverLat
-	public variable receiverLon
 	public variable receiverDataFormat
 	public variable adsbLocalPort
 	public variable adsbDataService

--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -79,8 +79,6 @@ proc connect_adsb_via_faup1090 {} {
 						-receiverType $receiverType \
 						-receiverHost $host \
 						-receiverPort $port \
-						-receiverLat $::receiverLat \
-						-receiverLon $::receiverLon \
 						-receiverDataFormat [receiver_data_format piawareConfig ES] \
 						-adsbLocalPort [receiver_local_port piawareConfig ES] \
 						-adsbDataService [receiver_local_service piawareConfig ES] \

--- a/programs/piaware/faup1090.tcl
+++ b/programs/piaware/faup1090.tcl
@@ -20,8 +20,8 @@ package require fa_services
 
 	protected method program_args {} {
 		set args [list "--net-bo-ipaddr" $receiverHost "--net-bo-port" $receiverPort "--stdout"]
-		if {$receiverLat ne "" && $receiverLon ne ""} {
-			lappend args "--lat" [format "%.3f" $receiverLat] "--lon" [format "%.3f" $receiverLon]
+		if {$::receiverLat ne "" && $::receiverLon ne ""} {
+			lappend args "--lat" [format "%.3f" $::receiverLat] "--lon" [format "%.3f" $::receiverLon]
 		}
 		return $args
 	}

--- a/programs/piaware/faup978.tcl
+++ b/programs/piaware/faup978.tcl
@@ -49,8 +49,6 @@ proc connect_uat_via_faup978 {} {
 					   -receiverType $receiverType \
 					   -receiverHost $host \
 					   -receiverPort $port \
-					   -receiverLat $::receiverLat \
-					   -receiverLon $::receiverLon \
 					   -receiverDataFormat [receiver_data_format piawareConfig UAT] \
 					   -adsbLocalPort [receiver_local_port piawareConfig UAT] \
 					   -adsbDataService [receiver_local_service piawareConfig UAT] \


### PR DESCRIPTION
Currently, when you change receiver location on My ADS-B stats, piaware invokes a faup1090 restart but faup1090 will continue to use the location that piaware first started up with. The new location won't take effect until you restart piaware.

This change should use the saved location info in all cases.