### PR TITLE
Add config variable "override-site-info-host"

### DIFF
--- a/package/fa_piaware_config.tcl
+++ b/package/fa_piaware_config.tcl
@@ -1063,6 +1063,8 @@ namespace eval ::fa_piaware_config {
 			{"uat-sdr-device"        -default "driver=rtlsdr" -sdonly 1}
 
 			{"use-gpsd"              -type boolean -default yes}
+
+			{"override-site-info-host"}
 		}
 
 		return [uplevel 1 ::fa_piaware_config::new ::fa_piaware_config::ConfigMetadata [list $name] [list $settings]]

--- a/programs/piaware/health.tcl
+++ b/programs/piaware/health.tcl
@@ -25,8 +25,23 @@ proc construct_health_array {_row} {
 
 	catch {
 		if {[::fa_sysinfo::route_to_flightaware gateway iface ip]} {
-			set row(local_ip) $ip
-			set row(local_iface) $iface
+
+			# get override-site-info-host
+			set osih [piawareConfig get override-site-info-host]
+
+			# if override-site-info-host is not set, then send the ip as-per fa_sysinfo
+			if {$osih eq ""} {
+				
+				set row(local_ip) $ip
+				set row(local_iface) $iface
+
+			# if override-site-info-host is set, then send the contents of override-site-info-host
+			} else {
+
+				set row(local_ip) $osih
+				set row(local_iface) $iface
+
+			}
 		}
 	}
 


### PR DESCRIPTION
As-per #70, this change implements config variable "override-site-info-host".

Users can use `piaware-config override-site-info-host x.x.x.x` to override the local IP address sent to FlightAware.

I'm running this on my station, site 78418. It seems to work fine.

- "Site Local IP" matches the IP I set override-site-info-host to
- The web interface link points to the correct IP

I haven't figured out how to change the port yet...