### PR TITLE
Systemd watchdog support

### DIFF
--- a/programs/piaware/main.tcl
+++ b/programs/piaware/main.tcl
@@ -30,6 +30,7 @@ source $::launchdir/pirehose.tcl
 source $::launchdir/update.tcl
 source $::launchdir/login.tcl
 source $::launchdir/statusfile.tcl
+source $::launchdir/systemd.tcl
 
 #
 # main - the main program
@@ -69,6 +70,9 @@ proc main {{argv ""}} {
 	interp bgerror {} log_bgerror
 
 	setup_config
+
+	# if we are running under systemd start sending watchdog resets if configured
+	systemd_start_watchdog
 
 	# setup adept client early so logger command won't trace back
 	# (this does not initiate a connection, it just creates the object)

--- a/programs/piaware/systemd.tcl
+++ b/programs/piaware/systemd.tcl
@@ -1,0 +1,33 @@
+# basic systemd watchdog support
+#
+# For now, this is very simple - reset the watchdog from the tcl event loop;
+# this is intended mostly to catch tcl-tls hanging in a way that freezes
+# the whole event loop.
+
+proc systemd_start_watchdog {} {
+	set ::systemd_notify [auto_execok systemd-notify]
+	if {$::systemd_notify eq ""} {
+		# no systemd-notify in path, probably not a systemd system at all
+		return
+	}
+
+	if {![info exists ::env(WATCHDOG_USEC)]} {
+		# no watchdog requested
+		return
+	}
+
+	if {[info exists ::env(WATCHDOG_PID)] && $::env(WATCHDOG_PID) != [pid]} {
+		# watchdog PID exists but is not our PID
+		return
+	}
+
+	set ::systemd_watchdog_interval_ms [expr {round($::env(WATCHDOG_USEC) * 0.8 / 1000.0)}]
+	unset ::env(WATCHDOG_USEC)	 ;# ensure that child processes don't think they need to do a watchdog
+
+	systemd_peridically_reset_watchdog
+}
+
+proc systemd_peridically_reset_watchdog {} {
+	after $::systemd_watchdog_interval_ms systemd_peridically_reset_watchdog
+	catch {exec -- {*}$::systemd_notify --pid=[pid] WATCHDOG=1}
+}

--- a/programs/piaware/systemd.tcl
+++ b/programs/piaware/systemd.tcl
@@ -24,10 +24,10 @@ proc systemd_start_watchdog {} {
 	set ::systemd_watchdog_interval_ms [expr {round($::env(WATCHDOG_USEC) * 0.8 / 1000.0)}]
 	unset ::env(WATCHDOG_USEC)	 ;# ensure that child processes don't think they need to do a watchdog
 
-	systemd_peridically_reset_watchdog
+	systemd_periodically_reset_watchdog
 }
 
-proc systemd_peridically_reset_watchdog {} {
-	after $::systemd_watchdog_interval_ms systemd_peridically_reset_watchdog
+proc systemd_periodically_reset_watchdog {} {
+	after $::systemd_watchdog_interval_ms systemd_periodically_reset_watchdog
 	catch {exec -- {*}$::systemd_notify --pid=[pid] WATCHDOG=1}
 }

--- a/scripts/piaware.service
+++ b/scripts/piaware.service
@@ -18,6 +18,9 @@ RestartSec=30
 # exit code 4 means login failed
 # exit code 6 means startup failed (bad args or missing MAC)
 RestartPreventExitStatus=4 6
+WatchdogSec=120
+WatchdogSignal=SIGKILL
+NotifyAccess=all
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
systemd watchdog support: periodically reset the watchdog from the tcl event loop.

This should help with cases where piaware hangs within tcl-tls -- in those cases the whole process is stuck, neither the tcl interpreter nor the tcl event loop have control, and so no watchdog resets will happen.

We run systemd-notify as a subprocess to do the watchdog reset, rather than doing the heavy lifting needed to wrap libsystemd and invoke sd_notify directly.