### PR TITLE
Widearea location support

### DIFF
--- a/programs/piaware/faup.tcl
+++ b/programs/piaware/faup.tcl
@@ -425,7 +425,7 @@ proc update_location {lat lon} {
 	# if the location moves by more than about 250m since
 	# the last time we updated
 
-	if {$::receiverLat ne "" && $::receiverLon ne ""} {
+	if {$::receiverLat ne "" && $::receiverLon ne "" && $lat ne "" && $lon ne ""} {
 		# approx distances in km along lat/lon axes, don't bother with the full GC distance
 		set dLat [expr {111 * ($::receiverLat - $lat)}]
 		set dLon [expr {111 * ($::receiverLon - $lon) * cos($lat * 3.1415927 / 180.0)}]

--- a/programs/piaware/faup.tcl
+++ b/programs/piaware/faup.tcl
@@ -435,21 +435,40 @@ proc update_location {lat lon} {
 		}
 	}
 
-	# changed nontrivially; restart dump1090 / faup1090 / skyaware978 to use the new values
+	# changed nontrivially; save new values and restart dump1090 / faup1090 / skyaware978 to use them
 	set ::receiverLat $lat
 	set ::receiverLon $lon
+	save_location_info $::receiverLat $::receiverLon
+
+	# .. but rate-limit how frequently we may restart
+	if {![info exists ::locationRestartTimer]} {
+		# If we have a pending restart, just let that happen normally.
+		# Otherwise, schedule a restart in a few seconds, but no sooner than 60 seconds after the last restart happened
+
+		if {![info exists ::lastLocationRestartTime]} {
+			set delay 5000
+		} else {
+			set delay [expr {max(5000, $::lastLocationRestartTime + 60000 - [clock milliseconds])}]
+		}
+
+		set ::locationRestartTimer [after $delay do_location_restart]
+	}
+}
+
+proc do_location_restart {} {
+	# Called from update_location via "after"
+	unset -nocomplain ::locationRestartTimer
+	set ::lastLocationRestartTime [clock milliseconds]
 
 	# speculatively restart dump1090/skyaware978 even if we are not using it as a receiver;
 	# it may be used for display.
-	if {[save_location_info $lat $lon]} {
-		logger "Receiver location changed, restarting dump1090 and skyaware978"
-		::fa_services::attempt_service_restart dump1090 restart
-		::fa_services::attempt_service_restart skyaware978 restart
-	}
+	logger "Receiver location changed, restarting dump1090 and skyaware978"
+	::fa_services::attempt_service_restart dump1090 restart
+	::fa_services::attempt_service_restart skyaware978 restart
 
 	if {[info exists ::faup1090] && [$::faup1090 is_connected]} {
 		logger "Restarting faup1090"
-		restart_faup1090 5
+		restart_faup1090 now
 	}
 }
 

--- a/programs/piaware/health.tcl
+++ b/programs/piaware/health.tcl
@@ -126,9 +126,10 @@ proc location_data_changed {} {
 		}
 	}
 
-	if {$newloc eq ""} {
+	if {$newloc eq "" || $::wideAreaMode} {
 		# no valid position
 		adept set_location ""
+		update_location "" ""
 		return
 	}
 

--- a/programs/piaware/helpers.tcl
+++ b/programs/piaware/helpers.tcl
@@ -349,6 +349,12 @@ proc create_cache_dir {} {
 proc try_save_location_info {lat lon} {
 	create_cache_dir
 
+	if {$lat eq "" || $lon eq ""} {
+		file delete -- $::params(cachedir)/location
+		file delete -- $::params(cachedir)/location.env
+		return
+	}
+
 	set fp [open "$::params(cachedir)/location.new" w]
 	puts $fp $lat
 	puts $fp $lon

--- a/programs/piaware/login.tcl
+++ b/programs/piaware/login.tcl
@@ -118,6 +118,16 @@ proc handle_login_result {data} {
 			unset -nocomplain ::siteURL
 		}
 
+		if {[info exists row(widearea)]} {
+			set ::wideAreaMode $row(widearea)
+		} else {
+			set ::wideAreaMode 0
+		}
+
+		if {$::wideAreaMode} {
+			# force a location update to remove any old cached location
+			update_location "" ""
+		}
 	} else {
 		# NB do more here, like UI stuff
 		log_locally "*******************************************"

--- a/programs/piaware/main.tcl
+++ b/programs/piaware/main.tcl
@@ -69,6 +69,7 @@ proc main {{argv ""}} {
 
 	interp bgerror {} log_bgerror
 
+	set ::wideAreaMode 0
 	setup_config
 
 	# if we are running under systemd start sending watchdog resets if configured


### PR DESCRIPTION
This is for the case where we knows that a feeder provides data from a wide area and we should not use a single reciever location for range checks or surface position decoding.