### PR TITLE
Adsb 14864 allow piaware startup without mac

### DIFF
--- a/programs/piaware/helpers.tcl
+++ b/programs/piaware/helpers.tcl
@@ -67,7 +67,7 @@ proc greetings {} {
 #
 proc setup_adept_client {} {
     ::fa_adept::AdeptClient adept \
-		-mac [get_mac_address_or_quit] \
+		-mac [get_mac_address] \
 		-showTraffic $::params(showtraffic) \
 		-logCommand ::log_locally \
 		-loginCommand ::gather_login_info \
@@ -375,12 +375,7 @@ proc try_save_location_info {lat lon} {
 #  to, emit a message to stderr and exit
 #
 proc get_mac_address_or_quit {} {
-	set mac [::fa_sysinfo::mac_address]
-	if {$mac == ""} {
-		puts stderr "software failed to determine MAC address of the device.  cannot proceed without it."
-		exit 6
-	}
-	return $mac
+	return [::fa_sysinfo::mac_address]
 }
 
 #

--- a/programs/piaware/helpers.tcl
+++ b/programs/piaware/helpers.tcl
@@ -371,8 +371,7 @@ proc try_save_location_info {lat lon} {
 
 
 #
-# get_mac_address_or_quit - return the mac address of eth0 or if unable
-#  to, emit a message to stderr and exit
+# get_mac_address - return mac address regardless if empty or valid
 #
 proc get_mac_address {} {
 	return [::fa_sysinfo::mac_address]

--- a/programs/piaware/helpers.tcl
+++ b/programs/piaware/helpers.tcl
@@ -374,7 +374,7 @@ proc try_save_location_info {lat lon} {
 # get_mac_address_or_quit - return the mac address of eth0 or if unable
 #  to, emit a message to stderr and exit
 #
-proc get_mac_address_or_quit {} {
+proc get_mac_address {} {
 	return [::fa_sysinfo::mac_address]
 }
 


### PR DESCRIPTION
There's an edge case where piaware cannot find MAC address on startup.
This causes piaware to exit with error 6.

MAC addresses are nice to have but not needed anymore. 
So we just return an empty string if MAC can't be found.