### PR TITLE
Configurable gpsd host and port

### DIFF
--- a/package/fa_piaware_config.tcl
+++ b/package/fa_piaware_config.tcl
@@ -1072,6 +1072,8 @@ namespace eval ::fa_piaware_config {
 			{"uat-sdr-device"        -default "driver=rtlsdr" -sdonly 1}
 
 			{"use-gpsd"              -type boolean -default yes}
+			{"gpsd-host"             -default "localhost"}
+			{"gpsd-port"             -type integer -default 2947}
 		}
 
 		return [uplevel 1 ::fa_piaware_config::new ::fa_piaware_config::ConfigMetadata [list $name] [list $settings]]

--- a/programs/piaware/health.tcl
+++ b/programs/piaware/health.tcl
@@ -164,7 +164,9 @@ proc adept_location_changed {lat lon alt altref override} {
 }
 
 proc connect_to_gpsd {} {
-	set ::gpsd [::fa_gps::GpsdClient #auto -callback gps_location_update]
+	set gpsdHost [piawareConfig get gpsd-host]
+	set gpsdPort [piawareConfig get gpsd-port]
+	set ::gpsd [::fa_gps::GpsdClient #auto -host $gpsdHost -port $gpsdPort -callback gps_location_update]
 	$::gpsd connect
 }
 


### PR DESCRIPTION
Useful for situations where another host on the local network has a GPS available and the remote `gpsd` has been configured to allow remote clients (`-G` flag in `gpsd`).